### PR TITLE
sm8350-common: nuke aw8697.ko

### DIFF
--- a/modules.load
+++ b/modules.load
@@ -1,6 +1,5 @@
 adsp_loader_dlkm.ko
 apr_dlkm.ko
-aw8697.ko
 bolero_cdc_dlkm.ko
 bt_fm_slim.ko
 btpower.ko


### PR DESCRIPTION
nuke aw8697.ko as its not needed